### PR TITLE
Performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,6 @@ name = "thorin-dwp"
 version = "0.1.1"
 dependencies = [
  "gimli",
- "indexmap",
  "object",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +127,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +153,9 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -458,6 +483,7 @@ name = "thorin-dwp"
 version = "0.1.1"
 dependencies = [
  "gimli",
+ "hashbrown",
  "object",
  "tracing",
 ]
@@ -611,6 +637,12 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/thorin/Cargo.toml
+++ b/thorin/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 
 [dependencies]
 tracing = "0.1.29"
+hashbrown = "0.11.2"
 
 [dependencies.gimli]
 version  = "0.26.1"

--- a/thorin/Cargo.toml
+++ b/thorin/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-indexmap = "1.7.0"
 tracing = "0.1.29"
 
 [dependencies.gimli]

--- a/thorin/src/package.rs
+++ b/thorin/src/package.rs
@@ -374,7 +374,7 @@ pub(crate) struct InProgressDwarfPackage<'file> {
     /// In-progress string table being accumulated.
     ///
     /// Used to write final `.debug_str.dwo` and `.debug_str_offsets.dwo`.
-    string_table: PackageStringTable<RunTimeEndian>,
+    string_table: PackageStringTable,
 
     /// Compilation unit index entries (offsets + sizes) being accumulated.
     cu_index_entries: Vec<IndexEntry>,
@@ -402,7 +402,7 @@ impl<'file> InProgressDwarfPackage<'file> {
         Self {
             endian,
             obj: DwarfPackageObject::new(architecture, endianness),
-            string_table: PackageStringTable::new(endian),
+            string_table: PackageStringTable::new(),
             cu_index_entries: Default::default(),
             tu_index_entries: Default::default(),
             contained_units: Default::default(),
@@ -707,7 +707,7 @@ impl<'file> InProgressDwarfPackage<'file> {
         let Self { mut obj, string_table, cu_index_entries, tu_index_entries, .. } = self;
 
         // Write `.debug_str` to the object.
-        let _ = obj.append_to_debug_str(string_table.finish().slice());
+        let _ = obj.append_to_debug_str(&string_table.finish());
 
         // Write `.debug_{cu,tu}_index` sections to the object.
         debug!("writing cu index");

--- a/thorin/src/relocate.rs
+++ b/thorin/src/relocate.rs
@@ -2,9 +2,10 @@
 //! to be fully relocated prior to parsing. Necessary to load object files that reference dwarf
 //! objects (not just executables). Implementation derived from Gimli's `dwarfdump` example.
 
-use std::{borrow::Cow, collections::HashMap};
+use std::borrow::Cow;
 
 use gimli;
+use hashbrown::HashMap;
 use object::{Object, ObjectSection, ObjectSymbol, RelocationKind, RelocationTarget};
 
 use crate::{Error, Result};

--- a/thorin/src/strings.rs
+++ b/thorin/src/strings.rs
@@ -48,7 +48,7 @@ impl<E: gimli::Endianity> PackageStringTable<E> {
         bytes: T,
     ) -> Result<PackageStringOffset> {
         let bytes = bytes.into();
-        assert!(!bytes.contains(&0));
+        debug_assert!(!bytes.contains(&0));
         let (index, is_new) = self.strings.insert_full(bytes.clone());
         let index = PackageStringId(index);
         if !is_new {

--- a/thorin/src/strings.rs
+++ b/thorin/src/strings.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
-
 use gimli::{
     write::{EndianVec, Writer},
     DebugStrOffsetsBase, DebugStrOffsetsIndex, DwarfFileType, Encoding, EndianSlice, Format,
     Section,
 };
+use hashbrown::HashMap;
 use tracing::debug;
 
 use crate::{


### PR DESCRIPTION
This approximately doubles the speed for a large test case (`thorin -e llvm-project/build/bin/opt -o opt.dwp`). (Interestingly, both `llvm-dwp` and my Ubuntu's `dwp` fail to handle this test case.)

Most of the time is still spend in `PackageStringTable::remap_str_offsets_section`. I think the main way we could further improve that is by using the strings in `PackageStringTable::data` as the hash keys instead of allocating a `Vec` for each one, but I don't know if that is possible with existing `HashMap` APIs. Maybe custom allocators will allow this.

I also tried `radix_trie`, but it is much slower.