### PR TITLE
Update `object` dependency to 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +127,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +153,9 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -242,12 +267,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "7ce8b38d41f9f3618fc23f908faae61510f8d8ce2d99cbe910641e8f1971f084"
 dependencies = [
  "crc32fast",
  "flate2",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -612,6 +638,12 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/thorin-bin/Cargo.toml
+++ b/thorin-bin/Cargo.toml
@@ -24,7 +24,7 @@ tracing-tree = "0.1.10"
 typed-arena = "2.0.1"
 
 [dependencies.object]
-version  = "0.27.1"
+version  = "0.28.1"
 default-features = false
 features = [ "archive", "read", "write", "compression" ]
 

--- a/thorin/Cargo.toml
+++ b/thorin/Cargo.toml
@@ -23,7 +23,7 @@ default-features = false
 features = [ "read", "write", "std" ]
 
 [dependencies.object]
-version  = "0.27.1"
+version  = "0.28.1"
 default-features = false
 features = [ "archive", "read", "write", "compression" ]
 


### PR DESCRIPTION
This PR simply updates the `object` dependency from 0.27 to 0.28.

`rust_codegen_ssa` [now depends on 0.28](https://github.com/rust-lang/rust/blob/86f7f78f05ff8295aad2ad2a31770ce4408cc849/compiler/rustc_codegen_ssa/Cargo.toml#L43-L46) since https://github.com/rust-lang/rust/pull/90001. Whenever thorin is updated in rustc in the future, removing the use of 0.27 would deduplicate them.