### PR TITLE
Upgrade hashbrown, indexmap, and object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 dependencies = [
  "ahash",
 ]
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce8b38d41f9f3618fc23f908faae61510f8d8ce2d99cbe910641e8f1971f084"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "thorin-dwp"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "gimli",
  "hashbrown",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "thorin-dwp-bin"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "memmap2",

--- a/thorin-bin/Cargo.toml
+++ b/thorin-bin/Cargo.toml
@@ -24,7 +24,7 @@ tracing-tree = "0.1.10"
 typed-arena = "2.0.1"
 
 [dependencies.object]
-version  = "0.28.1"
+version = "0.29.0"
 default-features = false
 features = [ "archive", "read", "write", "compression" ]
 

--- a/thorin/Cargo.toml
+++ b/thorin/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 
 [dependencies]
 tracing = "0.1.29"
-hashbrown = "0.11.2"
+hashbrown = "0.12.0"
 
 [dependencies.gimli]
 version  = "0.26.1"
@@ -23,7 +23,7 @@ default-features = false
 features = [ "read", "write", "std" ]
 
 [dependencies.object]
-version  = "0.28.1"
+version = "0.29.0"
 default-features = false
 features = [ "archive", "read", "write", "compression" ]
 


### PR DESCRIPTION
I'm working on a PR to update rust-lang/rust to hashbrown 0.12 everywhere, and thorin is the last holdout. We only need new versions of `indexmap` and `object` here, as well as upgrading the direct `hashbrown` dependency.