### PR TITLE
release version 0.4.0

### DIFF
--- a/thorin-bin/Cargo.toml
+++ b/thorin-bin/Cargo.toml
@@ -8,11 +8,11 @@ keywords = ["dwarf", "split-dwarf", "dwarf-package", "dwarf-object", "dwp"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang/thorin"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]
-thorin-dwp = { version = "0.3.0", path = "../thorin" }
+thorin-dwp = { version = "0.4.0", path = "../thorin" }
 
 anyhow = "1.0.51"
 memmap2 = "0.5.0"

--- a/thorin-bin/README.md
+++ b/thorin-bin/README.md
@@ -16,7 +16,7 @@ objects (including DWARF objects in archive files, such as Rust rlibs)! Install 
 ```shell-session
 $ cargo install thorin-dwp-bin
 $ thorin --help
-thorin 0.3.0
+thorin 0.4.0
 merge dwarf objects into dwarf packages
 
 USAGE:

--- a/thorin/Cargo.toml
+++ b/thorin/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["dwarf", "split-dwarf", "dwarf-package", "dwarf-object", "dwp"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang/thorin"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/thorin/README.md
+++ b/thorin/README.md
@@ -12,7 +12,7 @@ cross-crate Split DWARF packaging in `rustc`.
 To use `thorin` in your own project, add it to your `Cargo.toml`:
 
 ```toml
-thorin-dwp = "0.3.0"
+thorin-dwp = "0.4.0"
 ```
 
 See the [`thorin-bin`](../thorin-bin/README.md) crate for an example of using `thorin`'s library


### PR DESCRIPTION
Already released to crates.io. Includes all changes since c454f85:

- e0382f2 Bump object crate to 0.30.0

cc @Amanieu (waiting on e0382f2 to be released)