### PR TITLE
Bump object to 0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,15 +404,16 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "d08090140cfee2e09897d6be320b47a45b79eb68b414de87130f9532966e2f1d"
 dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.13.2",
  "indexmap",
  "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -488,6 +495,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "ruzstd"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
+dependencies = [
+ "byteorder",
+ "thiserror",
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +554,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -618,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "thorin-dwp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "gimli",
  "hashbrown 0.12.3",
@@ -628,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "thorin-dwp-bin"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "memmap2",
@@ -739,6 +763,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/thorin-bin/Cargo.toml
+++ b/thorin-bin/Cargo.toml
@@ -24,7 +24,7 @@ tracing-tree = "0.1.10"
 typed-arena = "2.0.1"
 
 [dependencies.object]
-version = "0.30.0"
+version = "0.31.0"
 default-features = false
 features = [ "archive", "read", "write", "compression" ]
 

--- a/thorin/Cargo.toml
+++ b/thorin/Cargo.toml
@@ -23,7 +23,7 @@ default-features = false
 features = [ "read", "write", "std" ]
 
 [dependencies.object]
-version = "0.30.0"
+version = "0.31.0"
 default-features = false
 features = [ "archive", "read", "write", "compression" ]
 

--- a/thorin/src/lib.rs
+++ b/thorin/src/lib.rs
@@ -1,3 +1,5 @@
+pub extern crate object;
+
 use std::{
     borrow::Cow,
     collections::HashSet,


### PR DESCRIPTION
This is needed for https://github.com/rust-lang/rust/issues/106021.

I've also reexported `object`. This would enable the error in https://github.com/rust-lang/rust/issues/106021#issuecomment-1513970900 to be worked around without needing a thorin update.

Note that this adds a dependency on `ruzstd` for decompression.