### PR TITLE
bump `gimli` to 0.31 to avoid duplicate in `rust-lang/rust`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e1d97fbe9722ba9bbd0c97051c2956e726562b61f86a25a4360398a40edfc9"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 dependencies = [
  "fallible-iterator",
  "indexmap",

--- a/thorin/Cargo.toml
+++ b/thorin/Cargo.toml
@@ -16,7 +16,7 @@ tracing = "0.1.29"
 hashbrown = "0.14.0"
 
 [dependencies.gimli]
-version  = "0.30.0"
+version  = "0.31.0"
 default-features = false
 # `gimli/std` pulls in `fallible-iterator` which we don't use, but can't opt out of, because of
 # cargo#8832.


### PR DESCRIPTION
I'm trying to remove the duplicate `object` dependencies in `rust-lang/rust`. Bumping to `thorin-0.8.0` would help, but it would also introduce a duplicate in `gimli` by depending on 0.30 while it's already at 0.31 in rust.

This PR updates `gimli` to 0.31 so that whenever a `thorin` release and bump happen, this dependency won't be duplicated.