### PR TITLE
use release-plz trusted publishing implementation

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -20,16 +20,12 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@v1
-        id: auth
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   release-plz-pr:
     name: Release-plz PR


### PR DESCRIPTION
The latest release-plz version implements trusted publishing, so there's no need to use the `crates-io-auth-action`.

The advantage is that release-plz will request tokens to crates.io only when a release needs to happen.
Instead, right now CI requests for a token on every commit on the main branch, which is a waste of resources.

This PR should be ready to be merged because no settings changes should be required.