### PR TITLE
Upgrade to object v0.39, itertools v0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,18 +181,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1033caf0b349c518623b5396bfb2cf0bddf44f0306d543a250e5743297aafd10"
 dependencies = [
  "fnv",
- "hashbrown 0.17.1",
+ "hashbrown",
  "indexmap",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -214,12 +205,12 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -300,13 +291,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.38.1"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
  "flate2",
- "hashbrown 0.16.1",
+ "hashbrown",
  "indexmap",
  "memchr",
  "ruzstd",
@@ -443,7 +434,7 @@ name = "thorin-dwp"
 version = "0.10.0"
 dependencies = [
  "gimli",
- "hashbrown 0.17.1",
+ "hashbrown",
  "itertools",
  "object",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]

--- a/thorin-bin/Cargo.toml
+++ b/thorin-bin/Cargo.toml
@@ -24,7 +24,7 @@ tracing-tree = "0.4.1"
 typed-arena = "2.0.2"
 
 [dependencies.object]
-version = "0.38.0"
+version = "0.39.0"
 default-features = false
 features = [ "archive", "read", "write", "compression" ]
 

--- a/thorin/Cargo.toml
+++ b/thorin/Cargo.toml
@@ -28,7 +28,7 @@ default-features = false
 features = [ "read", "write", "std" ]
 
 [dependencies.object]
-version = "0.38.0"
+version = "0.39.0"
 default-features = false
 features = [ "archive", "read", "write", "compression" ]
 

--- a/thorin/Cargo.toml
+++ b/thorin/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 gc = []
 
 [dependencies]
-itertools = "0.12"
+itertools = "0.15"
 tracing = "0.1.44"
 hashbrown = "0.17.0"
 


### PR DESCRIPTION
No code changes required.

This incidentally forced a compatible `indexmap` update too, which resolved the duplicate `hashbrown` dependencies.